### PR TITLE
added ph calibration endpoints

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -25,7 +25,7 @@
         # Put `false` as second element:
         {Credo.Check.Design.TagFIXME, false},
 
-        # ... several checks omitted for readability ...
+        {Credo.Check.Readability.ModuleDoc, false}
       ]
     }
   ]

--- a/lib/bio_monitor/routine_monitor.ex
+++ b/lib/bio_monitor/routine_monitor.ex
@@ -123,7 +123,6 @@ defmodule BioMonitor.RoutineMonitor do
   end
 
   defp fetch_reading(routine_id) do
-    IO.puts 'Fetching reading from sensors.'
     with {:ok, data} <- SensorManager.get_readings() do
       with routine = Repo.get(Routine, routine_id),
         true <- routine != nil,

--- a/lib/bio_monitor/sensor_manager.ex
+++ b/lib/bio_monitor/sensor_manager.ex
@@ -42,6 +42,26 @@ defmodule BioMonitor.SensorManager do
   end
 
   @doc """
+    Fetch the ph value from the sensor.
+  """
+  def get_ph do
+    case get_readings() do
+      {:ok, readings} -> {:ok, readings[:ph]}
+      _ -> {:error, "Error while fetching the current ph value"}
+    end
+  end
+
+  @doc """
+    sets the offset of the ph sensor for calibration
+  """
+  def set_ph_offset(offset) do
+    case send_command(:ph, "setPhOffset:#{offset}") do
+      {:ok, _result} -> :ok
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  @doc """
     Fetchs all readings from the SerialMonitors and parse them.
   """
   def get_readings do

--- a/test/controllers/ph_controller_test.exs
+++ b/test/controllers/ph_controller_test.exs
@@ -1,0 +1,33 @@
+defmodule BioMonitor.PhControllerTest do
+  use BioMonitor.ConnCase
+
+  @moduledoc """
+    Test cases for PhController
+    The commented tests won't pass unless the board is connected.
+  """
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  # test "returns current ph value", %{conn: conn} do
+  #   conn = get conn, ph_path(conn, :current)
+  #   assert json_response(conn, 200)["current_value"] != nil
+  # end
+
+  # test "sets offset ph value", %{conn: conn} do
+  #   conn = get conn, ph_path(conn, :current, %{"offset" => "#{0.3}"})
+  #   assert json_response(conn, 200)["current_value"] != nil
+  # end
+
+  test "fails to return current ph value", %{conn: conn} do
+    conn = get conn, ph_path(conn, :current)
+    assert response(conn, 422)
+  end
+
+  test "sets offset ph value", %{conn: conn} do
+    conn = get conn, ph_path(conn, :current, %{"offset" => "#{0.3}"})
+    assert response(conn, 422)
+  end
+
+end

--- a/test/controllers/routine_controller_test.exs
+++ b/test/controllers/routine_controller_test.exs
@@ -1,6 +1,10 @@
 defmodule BioMonitor.RoutineControllerTest do
   use BioMonitor.ConnCase
 
+  @moduledoc """
+    Test cases for RoutineController
+  """
+
   alias BioMonitor.Routine
   alias Ecto.DateTime, as: DateTime
   @valid_attrs %{title: Faker.File.file_name(), estimated_time_seconds: "#{Faker.Commerce.price()}", extra_notes: Faker.File.file_name(), medium: Faker.Beer.name(), strain: Faker.Beer.malt(), target_co2: "#{Faker.Commerce.price()}", target_density: "#{Faker.Commerce.price()}", target_ph: "#{Faker.Commerce.price()}", target_temp: "#{Faker.Commerce.price()}"}
@@ -73,7 +77,7 @@ defmodule BioMonitor.RoutineControllerTest do
   end
 
   defp to_date_string(date) do
-    {:ok, dateTime} = date |> DateTime.cast
-    dateTime |> DateTime.to_iso8601
+    {:ok, date_time} = date |> DateTime.cast
+    date_time |> DateTime.to_iso8601
   end
 end

--- a/test/models/routine_test.exs
+++ b/test/models/routine_test.exs
@@ -1,5 +1,8 @@
 defmodule BioMonitor.RoutineTest do
   use BioMonitor.ModelCase
+  @moduledoc """
+    Test cases for ph controller
+  """
 
   alias BioMonitor.Routine
 

--- a/web/controllers/ph_controller.ex
+++ b/web/controllers/ph_controller.ex
@@ -1,0 +1,37 @@
+defmodule BioMonitor.PhController do
+  use BioMonitor.Web, :controller
+
+  alias BioMonitor.SensorManager
+  alias BioMonitor.ErrorView
+
+  def current(conn, _params) do
+    case SensorManager.get_ph() do
+      {:ok, ph_value} ->
+        conn
+        |> render("show.json", current_value: ph_value)
+      {:error, message} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(ErrorView, "error.json", %{message: message})
+    end
+
+  end
+
+  def set_offset(conn, %{"offset" => offset}) do
+    with :ok <- SensorManager.set_ph_offset(offset),
+      {:ok, ph_value} <- SensorManager.get_ph()
+    do
+      conn
+      |> render("show.json", current_value: ph_value)
+    else
+      {:error, message} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(ErrorView, "error.json", %{message: message})
+      _ ->
+        conn
+        |> put_status(500)
+        |> render(ErrorView, "500.json")
+    end
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -10,6 +10,8 @@ defmodule BioMonitor.Router do
 
     post "/routines/stop", RoutineController, :stop
     post "/routines/start", RoutineController, :start
+    get "/ph/current", PhController, :current
+    post "/ph/offset", PhController, :set_offset
     resources "/routines", RoutineController, except: [:new, :edit] do
       resources "/readings", ReadingController, except: [:new, :edit, :update]
       get "/to_csv", RoutineController, :to_csv

--- a/web/views/ph_view.ex
+++ b/web/views/ph_view.ex
@@ -1,0 +1,11 @@
+defmodule BioMonitor.PhView do
+  use BioMonitor.Web, :view
+
+  def render("show.json", %{current_value: value}) do
+    render_current_value(value)
+  end
+
+  defp render_current_value(value) do
+    %{current_value: value}
+  end
+end


### PR DESCRIPTION
Added two services:
* `GET /ph/current` that returns `{current_value: 7.1}`.
* `POST /ph/offset` that receives body `{offset: 0.3}` and returns `{current_value: 7.1}`.

**The services will fail until we implement the board functionality to get ph readings and setting the offset of the sensor**