### PR TITLE
Added started and started_date params to routines

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,8 +33,7 @@ config :bio_monitor, BioMonitor.SensorManager,
     speed: 115_200,
     sensors: [
       temp: "getTemp",
-      ph: "getPh",
-      density: "getTurb"
+      ph: "getPh"
     ]
   ]
 

--- a/lib/bio_monitor/sensor_manager.ex
+++ b/lib/bio_monitor/sensor_manager.ex
@@ -77,10 +77,9 @@ defmodule BioMonitor.SensorManager do
   def get_readings do
     with {:ok, arduino_readings} <- SerialMonitor.get_readings(@arduino_gs),
       {:ok, temp} <- parse_reading(arduino_readings[:temp]),
-      {:ok, ph} <- parse_reading(arduino_readings[:ph]),
-      {:ok, density} <- parse_reading(arduino_readings[:density])
+      {:ok, ph} <- parse_reading(arduino_readings[:ph])
     do
-      {:ok, %{temp: temp, ph: ph, co2: 0, density: density}}
+      {:ok, %{temp: temp, ph: ph, co2: 0, density: 0}}
     else
       :error ->
         {:error, "Hubo un error al obtener las lecturas"}

--- a/priv/repo/migrations/20170923114615_add_started_to_routine.exs
+++ b/priv/repo/migrations/20170923114615_add_started_to_routine.exs
@@ -1,0 +1,10 @@
+defmodule BioMonitor.Repo.Migrations.AddStartedToRoutine do
+  use Ecto.Migration
+
+  def change do
+    alter table(:routines) do
+      add :started, :boolean, default: false
+      add :started_date, :naive_datetime
+    end
+  end
+end

--- a/priv/repo/migrations/20170923183104_add_tolerance_to_routine.exs
+++ b/priv/repo/migrations/20170923183104_add_tolerance_to_routine.exs
@@ -1,0 +1,10 @@
+defmodule BioMonitor.Repo.Migrations.AddToleranceToRoutine do
+  use Ecto.Migration
+
+  def change do
+    alter table(:routines) do
+      add :temp_tolerance, :float, default: 1.0
+      add :ph_tolerance, :float, default: 0.5
+    end
+  end
+end

--- a/priv/repo/migrations/20170923184146_add_loop_to_routine.exs
+++ b/priv/repo/migrations/20170923184146_add_loop_to_routine.exs
@@ -1,0 +1,9 @@
+defmodule BioMonitor.Repo.Migrations.AddLoopToRoutine do
+  use Ecto.Migration
+
+  def change do
+    alter table(:routines) do
+      add :loop_delay, :integer, default: 2_000
+    end
+  end
+end

--- a/test/controllers/routine_controller_test.exs
+++ b/test/controllers/routine_controller_test.exs
@@ -34,6 +34,8 @@ defmodule BioMonitor.RoutineControllerTest do
       "target_density" => routine.target_density,
       "estimated_time_seconds" => routine.estimated_time_seconds,
       "extra_notes" => routine.extra_notes,
+      "started" => false,
+      "started_date" => routine.started_date,
       "inserted_at" => to_date_string(routine.inserted_at),
       "updated_at" => to_date_string(routine.updated_at),
     }

--- a/test/controllers/routine_controller_test.exs
+++ b/test/controllers/routine_controller_test.exs
@@ -7,7 +7,7 @@ defmodule BioMonitor.RoutineControllerTest do
 
   alias BioMonitor.Routine
   alias Ecto.DateTime, as: DateTime
-  @valid_attrs %{title: Faker.File.file_name(), estimated_time_seconds: "#{Faker.Commerce.price()}", extra_notes: Faker.File.file_name(), medium: Faker.Beer.name(), strain: Faker.Beer.malt(), target_co2: "#{Faker.Commerce.price()}", target_density: "#{Faker.Commerce.price()}", target_ph: "#{Faker.Commerce.price()}", target_temp: "#{Faker.Commerce.price()}"}
+  @valid_attrs %{title: Faker.File.file_name(), estimated_time_seconds: "#{Faker.Commerce.price()}", extra_notes: Faker.File.file_name(), medium: Faker.Beer.name(), strain: Faker.Beer.malt(), target_co2: "#{Faker.Commerce.price()}", target_density: "#{Faker.Commerce.price()}", target_ph: "#{Faker.Commerce.price()}", target_temp: "#{Faker.Commerce.price()}", temp_tolerance: 2, ph_tolerance: 0.6, loop_delay: 5_000}
   @invalid_attrs %{}
 
   setup %{conn: conn} do
@@ -36,6 +36,9 @@ defmodule BioMonitor.RoutineControllerTest do
       "extra_notes" => routine.extra_notes,
       "started" => false,
       "started_date" => routine.started_date,
+      "ph_tolerance" => routine.ph_tolerance,
+      "temp_tolerance" => routine.temp_tolerance,
+      "loop_delay" => routine.loop_delay,
       "inserted_at" => to_date_string(routine.inserted_at),
       "updated_at" => to_date_string(routine.updated_at),
     }

--- a/web/models/routine.ex
+++ b/web/models/routine.ex
@@ -17,6 +17,9 @@ defmodule BioMonitor.Routine do
     field :uuid, :string
     field :started, :boolean
     field :started_date, :naive_datetime
+    field :temp_tolerance, :float
+    field :ph_tolerance, :float
+    field :loop_delay, :integer
     has_many :readings, BioMonitor.Reading
 
     timestamps()
@@ -27,7 +30,7 @@ defmodule BioMonitor.Routine do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:title, :strain, :medium, :target_temp, :target_ph, :target_co2, :target_density, :estimated_time_seconds, :extra_notes, :uuid])
+    |> cast(params, [:title, :strain, :medium, :target_temp, :target_ph, :target_co2, :target_density, :estimated_time_seconds, :extra_notes, :uuid, :temp_tolerance, :ph_tolerance, :loop_delay])
     |> validate_required([:title, :strain, :medium, :target_temp, :target_ph, :target_density, :estimated_time_seconds])
     |> generate_uuid
   end

--- a/web/models/routine.ex
+++ b/web/models/routine.ex
@@ -15,19 +15,30 @@ defmodule BioMonitor.Routine do
     field :estimated_time_seconds, :float
     field :extra_notes, :string
     field :uuid, :string
+    field :started, :boolean
+    field :started_date, :naive_datetime
     has_many :readings, BioMonitor.Reading
 
     timestamps()
   end
 
   @doc """
-  Builds a changeset based on the `struct` and `params`.
+    Builds a changeset based on the `struct` and `params`.
   """
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:title, :strain, :medium, :target_temp, :target_ph, :target_co2, :target_density, :estimated_time_seconds, :extra_notes, :uuid])
     |> validate_required([:title, :strain, :medium, :target_temp, :target_ph, :target_density, :estimated_time_seconds])
     |> generate_uuid
+  end
+
+  @doc """
+    Builds a changeset to update the started status of a routine.
+  """
+  def started_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:started, :started_date])
+    |> validate_required([:started, :started_date])
   end
 
   defp generate_uuid(changeset) do

--- a/web/views/reading_view.ex
+++ b/web/views/reading_view.ex
@@ -1,11 +1,8 @@
 defmodule BioMonitor.ReadingView do
   use BioMonitor.Web, :view
 
-  def render("index.json", %{readings: readings, page_info: page_info}) do
-    Map.merge(
-      %{data: render_many(readings, BioMonitor.ReadingView, "reading.json")},
-      page_info
-    )
+  def render("index.json", %{readings: readings}) do
+    %{data: render_many(readings, BioMonitor.ReadingView, "reading.json")}
   end
 
   def render("show.json", %{reading: reading}) do

--- a/web/views/routine_view.ex
+++ b/web/views/routine_view.ex
@@ -31,6 +31,9 @@ defmodule BioMonitor.RoutineView do
       started_date: routine.started_date,
       inserted_at: routine.inserted_at,
       updated_at: routine.updated_at,
+      ph_tolerance: routine.ph_tolerance,
+      loop_delay: routine.loop_delay,
+      temp_tolerance: routine.temp_tolerance
     }
   end
 

--- a/web/views/routine_view.ex
+++ b/web/views/routine_view.ex
@@ -27,6 +27,8 @@ defmodule BioMonitor.RoutineView do
       target_density: routine.target_density,
       estimated_time_seconds: routine.estimated_time_seconds,
       extra_notes: routine.extra_notes,
+      started: routine.started,
+      started_date: routine.started_date,
       inserted_at: routine.inserted_at,
       updated_at: routine.updated_at,
     }
@@ -34,5 +36,9 @@ defmodule BioMonitor.RoutineView do
 
   def render("unavailable.json", _assigns) do
     %{error: "El fermentador está trabajando en otro experimento en este momento."}
+  end
+
+  def render("already_run.json", _assigns) do
+    %{error: "El experimento ya fue corrido."}
   end
 end


### PR DESCRIPTION
* Added `started: (true|false)` and `started_date: (null | dateTime)` params to routine.
* `/routines/start` now fails if the routine has already been started.
* Removed pagination on readings index.