### PR TITLE
Added temp ranges

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,7 +19,7 @@ config :bio_monitor, BioMonitor.Endpoint,
 
 # Configures Elixir's Logger
 config :logger,
-  backends: [:console, Flames.Logger],
+  backends: [:console],
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
@@ -35,7 +35,8 @@ config :flames,
 # Configures ports and variables for Sensors.
 config :bio_monitor, BioMonitor.SensorManager,
   arduino: [
-    port: "/dev/cu.usbmodem1421",
+    # port: "/dev/cu.usbmodem1421",
+    port: "/dev/cu.SLAB_USBtoUART",
     speed: 115_200,
     sensors: [
       temp: "getTemp",

--- a/lib/bio_monitor/routine_message_broker.ex
+++ b/lib/bio_monitor/routine_message_broker.ex
@@ -17,6 +17,9 @@ defmodule BioMonitor.RoutineMessageBroker do
   @routine_error :reading_error
   @sensor_error :sensor_error
   @system_error :system_error
+  # Instructions channel
+  @instructions_channel "instructions"
+  @instruction "instruction"
 
   alias BioMonitor.Endpoint
   alias BioMonitor.SyncServer
@@ -121,6 +124,16 @@ defmodule BioMonitor.RoutineMessageBroker do
         status: @routine_error,
         message: "Hubo un error al guardar una lectura.",
         errors: [message]
+      }
+    )
+  end
+
+  def send_instruction(message) do
+    Endpoint.broadcast(
+      @instructions_channel,
+      @instruction,
+      %{
+        message: message,
       }
     )
   end

--- a/priv/repo/migrations/20171007185655_create_temp_range.exs
+++ b/priv/repo/migrations/20171007185655_create_temp_range.exs
@@ -1,0 +1,15 @@
+defmodule BioMonitor.Repo.Migrations.CreateTempRange do
+  use Ecto.Migration
+
+  def change do
+    create table(:temp_ranges) do
+      add :temp, :integer
+      add :from_second, :integer
+      add :routine_id, references(:routines, on_delete: :nothing)
+
+      timestamps()
+    end
+    create index(:temp_ranges, [:routine_id])
+
+  end
+end

--- a/test/channels/instructions_channel_test.exs
+++ b/test/channels/instructions_channel_test.exs
@@ -10,19 +10,4 @@ defmodule BioMonitor.InstructionsChannelTest do
 
     {:ok, socket: socket}
   end
-
-  test "ping replies with status ok", %{socket: socket} do
-    ref = push socket, "ping", %{"hello" => "there"}
-    assert_reply ref, :ok, %{"hello" => "there"}
-  end
-
-  test "shout broadcasts to instructions:lobby", %{socket: socket} do
-    push socket, "shout", %{"hello" => "all"}
-    assert_broadcast "shout", %{"hello" => "all"}
-  end
-
-  test "broadcasts are pushed to the client", %{socket: socket} do
-    broadcast_from! socket, "broadcast", %{"some" => "data"}
-    assert_push "broadcast", %{"some" => "data"}
-  end
 end

--- a/test/channels/instructions_channel_test.exs
+++ b/test/channels/instructions_channel_test.exs
@@ -1,0 +1,28 @@
+defmodule BioMonitor.InstructionsChannelTest do
+  use BioMonitor.ChannelCase
+
+  alias BioMonitor.InstructionsChannel
+
+  setup do
+    {:ok, _, socket} =
+      socket("user_id", %{some: :assign})
+      |> subscribe_and_join(InstructionsChannel, "instructions:lobby")
+
+    {:ok, socket: socket}
+  end
+
+  test "ping replies with status ok", %{socket: socket} do
+    ref = push socket, "ping", %{"hello" => "there"}
+    assert_reply ref, :ok, %{"hello" => "there"}
+  end
+
+  test "shout broadcasts to instructions:lobby", %{socket: socket} do
+    push socket, "shout", %{"hello" => "all"}
+    assert_broadcast "shout", %{"hello" => "all"}
+  end
+
+  test "broadcasts are pushed to the client", %{socket: socket} do
+    broadcast_from! socket, "broadcast", %{"some" => "data"}
+    assert_push "broadcast", %{"some" => "data"}
+  end
+end

--- a/test/controllers/routine_controller_test.exs
+++ b/test/controllers/routine_controller_test.exs
@@ -42,6 +42,7 @@ defmodule BioMonitor.RoutineControllerTest do
       "loop_delay" => routine.loop_delay,
       "inserted_at" => to_date_string(routine.inserted_at),
       "updated_at" => to_date_string(routine.updated_at),
+      "temp_ranges" => [],
     }
   end
 

--- a/test/models/temp_range_test.exs
+++ b/test/models/temp_range_test.exs
@@ -1,0 +1,18 @@
+defmodule BioMonitor.TempRangeTest do
+  use BioMonitor.ModelCase
+
+  alias BioMonitor.TempRange
+
+  @valid_attrs %{from_second: 42, temp: 42}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = TempRange.changeset(%TempRange{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = TempRange.changeset(%TempRange{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/web/channels/instructions_channel.ex
+++ b/web/channels/instructions_channel.ex
@@ -1,5 +1,6 @@
 defmodule BioMonitor.InstructionsChannel do
   use BioMonitor.Web, :channel
+  intercept(["instruction"])
 
   def join("instructions", _payload, socket) do
     {:ok, socket}

--- a/web/channels/instructions_channel.ex
+++ b/web/channels/instructions_channel.ex
@@ -1,0 +1,12 @@
+defmodule BioMonitor.InstructionsChannel do
+  use BioMonitor.Web, :channel
+
+  def join("instructions", _payload, socket) do
+    {:ok, socket}
+  end
+
+  def handle_out("instruction", payload, socket) do
+    push socket, "instruction", payload
+    {:noreply, socket}
+  end
+end

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -3,6 +3,7 @@ defmodule BioMonitor.UserSocket do
 
   channel "routine", BioMonitor.RoutineChannel
   channel "sensors", BioMonitor.SensorChannel
+  channel "instructions", BioMonitor.InstructionsChannel
 
   transport :websocket, Phoenix.Transports.WebSocket
 

--- a/web/models/routine.ex
+++ b/web/models/routine.ex
@@ -22,6 +22,7 @@ defmodule BioMonitor.Routine do
     field :balance_ph, :boolean
     field :loop_delay, :integer
     has_many :readings, BioMonitor.Reading, on_delete: :delete_all
+    has_many :temp_ranges, BioMonitor.TempRange, on_delete: :delete_all
 
     timestamps()
   end
@@ -32,6 +33,7 @@ defmodule BioMonitor.Routine do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:title, :strain, :medium, :target_temp, :target_ph, :target_co2, :target_density, :estimated_time_seconds, :extra_notes, :uuid, :temp_tolerance, :ph_tolerance, :loop_delay, :balance_ph])
+    |> cast_assoc(:temp_ranges, required: false)
     |> validate_required([:title, :strain, :medium, :target_temp, :target_ph, :target_density, :estimated_time_seconds])
     |> generate_uuid
   end

--- a/web/models/temp_range.ex
+++ b/web/models/temp_range.ex
@@ -1,0 +1,20 @@
+defmodule BioMonitor.TempRange do
+  use BioMonitor.Web, :model
+
+  schema "temp_ranges" do
+    field :temp, :integer
+    field :from_second, :integer
+    belongs_to :routine, BioMonitor.Routine
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:temp, :from_second])
+    |> validate_required([:temp, :from_second])
+  end
+end

--- a/web/views/routine_view.ex
+++ b/web/views/routine_view.ex
@@ -34,7 +34,8 @@ defmodule BioMonitor.RoutineView do
       ph_tolerance: routine.ph_tolerance,
       balance_ph: routine.balance_ph,
       loop_delay: routine.loop_delay,
-      temp_tolerance: routine.temp_tolerance
+      temp_tolerance: routine.temp_tolerance,
+      temp_ranges: render_temp_ranges(routine)
     }
   end
 
@@ -44,5 +45,12 @@ defmodule BioMonitor.RoutineView do
 
   def render("already_run.json", _assigns) do
     %{error: "El experimento ya fue corrido."}
+  end
+
+  defp render_temp_ranges(routine) do
+    routine.temp_ranges
+    |> Enum.map(fn range ->
+      %{temp: range.temp, from_second: range.from_second}
+    end)
   end
 end


### PR DESCRIPTION
Now the routine endpoint accepts 
```json
{
......The rest of the old parameters.......,
temp_ranges: [
  {
     "temp": 10,
     "from_second": 40
  },
  {
     "temp": 25,
     "from_second": 80
  }
]
}
```

The target_temp set in routine is used as a default if there is no range set for that period of time (or any in that case).