### PR TITLE
Updated sensors status to use new board service

### DIFF
--- a/lib/bio_monitor/routine_processing.ex
+++ b/lib/bio_monitor/routine_processing.ex
@@ -16,7 +16,7 @@ defmodule BioMonitor.RoutineProcessing do
   @temp_too_low_message "La temperatura está por debajo del rango establecido."
 
   def get_sensors_status do
-    case SensorManager.get_readings()  do
+    case SensorManager.get_sensors_status()  do
       {:ok, data} ->
         Broker.send_status(data)
       {:error, message} ->

--- a/web/controllers/routine_controller.ex
+++ b/web/controllers/routine_controller.ex
@@ -4,7 +4,7 @@ defmodule BioMonitor.RoutineController do
   alias BioMonitor.Routine
   alias BioMonitor.CloudSync
 
-  @routines_per_page "100"
+  @routines_per_page "20"
 
   def index(conn, params) do
     {routines, rummage} =
@@ -86,6 +86,7 @@ defmodule BioMonitor.RoutineController do
       :ready <- already_run(routine),
       :ok <- BioMonitor.RoutineMonitor.start_routine(routine)
     do
+      IO.inspect routine
       render(conn, "show.json", routine: routine)
     else
       {:error, _, message} ->


### PR DESCRIPTION
* Now the status channels sends the following payload: 
```json
{
   "ph" : "ON/OFF",
   "pumps": "ON/OFF",
   "temp": "ON/OFF"
}
```
The payload in case of an error (such as when the board is not connected) is the same as before.
