### PR TITLE
Added state recovery logic to routine monitor

### DIFF
--- a/lib/bio_monitor.ex
+++ b/lib/bio_monitor.ex
@@ -17,6 +17,7 @@ defmodule BioMonitor do
     ]
 
     opts = [strategy: :one_for_one, name: BioMonitor.Supervisor]
+    BioMonitor.StateContainer.start_link()
     Supervisor.start_link(children, opts)
   end
 

--- a/lib/bio_monitor/state_container.ex
+++ b/lib/bio_monitor/state_container.ex
@@ -1,0 +1,40 @@
+defmodule BioMonitor.StateContainer do
+  @moduledoc """
+    Simple module that stores the state of the routine monitor process isolatedly.
+  """
+
+  defmodule InternalState do
+    defstruct retry_count: 0, state: nil
+  end
+
+  @name StateContainer
+
+  # Starts the state with a empty set.
+  def start_link() do
+    Agent.start_link(fn -> %InternalState{} end, name: @name)
+  end
+
+  def update_state(new_state) do
+    IO.puts "============ NEW STATE ================"
+    IO.inspect new_state
+    Agent.update(@name, fn state -> %{state | state: new_state} end)
+  end
+
+  def update_retry_count(new_count) do
+    IO.puts "============ Retry Count ================"
+    IO.inspect new_count
+    Agent.update(@name, fn state -> %{state | retry_count: new_count} end)
+  end
+
+  def reset() do
+    Agent.update(@name, fn state -> %InternalState{} end)
+  end
+
+  def state() do
+    Agent.get(@name, fn state -> state.state end)
+  end
+
+  def retry_count() do
+    Agent.get(@name, fn state -> state.retry_count end)
+  end
+end


### PR DESCRIPTION
State is now stored in a separate process after the routine proces crashes.
The recovery strategy is the following:
- If it's there is no previous state stored, business as usual.
- If there is a state stored, and the retry count is less than 3, the process waits 10 seconds and then tries to start again with the old state.
- If the retry count is more than 3, or there is no state, the process goes back to the initial state.